### PR TITLE
Allow nodeenv in bootstrap script.

### DIFF
--- a/setup/bootstrap.sh
+++ b/setup/bootstrap.sh
@@ -56,7 +56,7 @@ if [ $ENKETO_EXPRESS_USE_NODE_ENV = "true" ]; then
     apt-get install python-pip
     pip install nodeenv
     nodeenv env
-    source env/bin/activate
+    . env/bin/activate
 else
     add-apt-repository ppa:chris-lea/node.js
     apt-get update


### PR DESCRIPTION
Added an override in `bootstrap.sh` to allow using [`nodeenv`](http://ekalinin.github.io/nodeenv/) for installing Node. Needed this for KoBo offline because `npm` installations for KoBoCat and/or KoBoForm were apparently conflicting with Enketo Express's dependencies.

Successfully tested the Enketo Express Vagrant image in Ubuntu 14.04.
