### PR TITLE
have bug report link break out of iframe

### DIFF
--- a/app/views/surveys/webform.jade
+++ b/app/views/surveys/webform.jade
@@ -17,7 +17,7 @@ block script
 block content
   if manifest
     .alert-box.info(style="text-align: center;") Offline-enabled forms are experimental. Use only for testing. 
-      a(href="https://github.com/kobotoolbox/enketo-express/issues") Report new bugs
+      a(href="https://github.com/kobotoolbox/enketo-express/issues" target="_top") Report new bugs
       | .
   .main
     article.paper


### PR DESCRIPTION
If enketo is embedded in an iframe the github issues link will not load because github sets X-Frame-Options: deny. As is if you click on the link when enketo is in a iframe you get a blank page.

This PR sets the link target to top, so the the page loads the github issues page outside of any framing.

This seams generally useful so I figured I'd open, but your call. I could imagine a scenario where seeing a blank page is better than replacing a frame, for our use-case it is not.