### PR TITLE
ME: using decodeURIComponent to decode returnUrl

### DIFF
--- a/public/js/src/module/controller-webform.js
+++ b/public/js/src/module/controller-webform.js
@@ -257,7 +257,7 @@ function _submitRecord() {
                 msg += '<br/>' + t( 'alert.submissionsuccess.redirectmsg' );
                 gui.alert( msg, t( 'alert.submissionsuccess.heading' ), level );
                 setTimeout( function() {
-                    location.href = settings.returnUrl;
+                    location.href = decodeURIComponent( settings.returnUrl );
                 }, 1500 );
             } else {
                 msg = ( msg.length > 0 ) ? msg : t( 'alert.submissionsuccess.msg' );


### PR DESCRIPTION
Hi, so we were testing url redirect after submission editing and we noticed that we were getting a 404 after a successful edit mainly because the url being redirected to was encoded. We added `decodeURIComponent` function which fixed our problem hence the reason for this PR. Kindly review and let us know if this is the correct approach