### PR TITLE
Fix: _uploadBatch now respect settings.basePath

### DIFF
--- a/public/js/src/module/connection.js
+++ b/public/js/src/module/connection.js
@@ -132,7 +132,7 @@ function getDownloadUrl( zipFile ) {
 function _uploadBatch( recordBatch ) {
     return new Promise( function( resolve, reject ) {
         // submission URL is dynamic
-        var submissionUrl = ( settings.enketoId ) ? '/submission/' + settings.enketoIdPrefix + settings.enketoId +
+        var submissionUrl = ( settings.enketoId ) ? settings.basePath + '/submission/' + settings.enketoIdPrefix + settings.enketoId +
             utils.getQueryString( settings.submissionParameter ) : null;
         $.ajax( submissionUrl, {
                 type: 'POST',


### PR DESCRIPTION
After migrating enketo to latest version with basePath support my offline forms got broken. This fix provides proper URL if enketo is not working in /