### PR TITLE
Fix resource saving in offline forms

### DIFF
--- a/public/js/src/module/store.js
+++ b/public/js/src/module/store.js
@@ -315,7 +315,7 @@ surveyStore = {
                     enketoId: survey.enketoId,
                     hash: survey.hash,
                     theme: survey.theme,
-                    resources: resourceKeys,
+                    resources: survey.resources,
                     maxSize: survey.maxSize,
                     externalData: survey.externalData,
                     branding: survey.branding


### PR DESCRIPTION
Currently instead of persisting resource, only resource urls are saved, which results into (for example) branding logo being empty on second (but not first!) load